### PR TITLE
Support benchmark results with decimal dot

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -202,7 +202,8 @@ function extractBenchmarkJsResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   fib(20) x 11,465 ops/sec ±1.12% (91 runs sampled)
-    const reExtract = /^ x ([0-9,]+)\s+(\S+)\s+((?:±|\+-)[^%]+%) \((\d+) runs sampled\)$/; // Note: Extract parts after benchmark name
+    //   createObjectBuffer with 200 comments x 81.61 ops/sec ±1.70% (69 runs sampled)
+    const reExtract = /^ x ([0-9,.]+)\s+(\S+)\s+((?:±|\+-)[^%]+%) \((\d+) runs sampled\)$/; // Note: Extract parts after benchmark name
     const reComma = /,/g;
 
     for (const line of lines) {
@@ -218,7 +219,7 @@ function extractBenchmarkJsResult(output: string): BenchmarkResult[] {
             continue;
         }
 
-        const value = parseInt(m[1].replace(reComma, ''), 10);
+        const value = parseFloat(m[1].replace(reComma, ''));
         const unit = m[2];
         const range = m[3];
         const extra = `${m[4]} samples`;

--- a/test/data/extract/benchmarkjs_output.txt
+++ b/test/data/extract/benchmarkjs_output.txt
@@ -1,2 +1,3 @@
 fib(10) x 1,431,759 ops/sec ±0.74% (93 runs sampled)
 fib(20) x 12,146 ops/sec ±0.32% (96 runs sampled)
+createObjectBuffer with 200 comments x 81.61 ops/sec ±1.70% (69 runs sampled)

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -77,6 +77,13 @@ describe('extractResult()', function() {
                     value: 12146,
                     extra: '96 samples',
                 },
+                {
+                    name: 'createObjectBuffer with 200 comments',
+                    range: '±1.70%',
+                    unit: 'ops/sec',
+                    value: 81.61,
+                    extra: '69 samples',
+                },
             ],
         },
         {


### PR DESCRIPTION
benchmarkjs may have results with decimal dot
For example:
`createObjectBuffer with 200 comments x 81.61 ops/sec ±1.70% (69 runs sampled)`