### PR TITLE
Feature/catch multiline benchmarks

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -317,7 +317,7 @@ function extractCatch2Result(output: string): BenchmarkResult[] {
 
     const reTestCaseStart = /^benchmark name +samples +iterations +estimated/;
     const reBenchmarkStart = /(\d+) +(\d+) +(?:\d+(\.\d+)?) (?:ns|ms|us|s)\s*$/;
-    const reBenchmarkValues = /^ +(\d+(?:\.\d+)?) (ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s)/;
+    const reBenchmarkValues = /^(?:.*) +(\d+(?:\.\d+)?) (ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s)/;
     const reEmptyLine = /^\s*$/;
     const reSeparator = /^-+$/;
 

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -317,7 +317,7 @@ function extractCatch2Result(output: string): BenchmarkResult[] {
 
     const reTestCaseStart = /^benchmark name +samples +iterations +estimated/;
     const reBenchmarkStart = /(\d+) +(\d+) +(?:\d+(\.\d+)?) (?:ns|ms|us|s)\s*$/;
-    const reBenchmarkValues = /^(?:.*) +(\d+(?:\.\d+)?) (ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s)/;
+    const reBenchmarkValues = /^(.*) +(\d+(?:\.\d+)?) (ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s) +(?:\d+(?:\.\d+)?) (?:ns|us|ms|s)/;
     const reEmptyLine = /^\s*$/;
     const reSeparator = /^-+$/;
 
@@ -340,7 +340,7 @@ function extractCatch2Result(output: string): BenchmarkResult[] {
         }
 
         const extra = `${start[1]} samples\n${start[2]} iterations`;
-        const name = startLine.slice(0, start.index).trim();
+        let name = startLine.slice(0, start.index).trim();
 
         const [meanLine, meanLineNum] = nextLine();
         const mean = meanLine?.match(reBenchmarkValues);
@@ -351,8 +351,12 @@ function extractCatch2Result(output: string): BenchmarkResult[] {
             );
         }
 
-        const value = parseFloat(mean[1]);
-        const unit = mean[2];
+        const nameAddition = mean[1].trim();
+        if (nameAddition.trim() !== '') {
+            name += ' ' + nameAddition.trim();
+        }
+        const value = parseFloat(mean[2]);
+        const unit = mean[3];
 
         const [stdDevLine, stdDevLineNum] = nextLine();
         const stdDev = stdDevLine?.match(reBenchmarkValues);
@@ -363,7 +367,7 @@ function extractCatch2Result(output: string): BenchmarkResult[] {
             );
         }
 
-        const range = '± ' + stdDev[1].trim();
+        const range = '± ' + stdDev[2].trim();
 
         // Skip empty line
         const [emptyLine, emptyLineNum] = nextLine();

--- a/test/data/extract/catch2_output.txt
+++ b/test/data/extract/catch2_output.txt
@@ -4,14 +4,15 @@ Catch2_bench is a Catch v2.11.0 host application.
 Run with -? for options
 
 -------------------------------------------------------------------------------
-Fibonacci
+Unit_assignment
+  Construction
 -------------------------------------------------------------------------------
 /Users/rhayasd/Develop/github.com/rhysd/github-action-benchmark/examples/catch2/catch2_bench.cpp:5
 ...............................................................................
 
-benchmark name                                  samples       iterations    estimated
-                                                mean          low mean      high mean
-                                                std dev       low std dev   high std dev
+benchmark name                       samples       iterations    estimated
+                                     mean          low mean      high mean
+                                     std dev       low std dev   high std dev
 -------------------------------------------------------------------------------
 Fibonacci 10                                              100           208     7.1968 ms 
                                                        344 ns        341 ns        349 ns 
@@ -38,7 +39,27 @@ Fibonacci~ 5!                                             100          1961     
                                                                                           
 Fibonacci-15_bench                                        100            20       7.48 ms 
                                                      3.789 us      3.734 us      3.888 us 
-                                                       362 ns        234 ns        539 ns 
+                                                       362 ns        234 ns        539 ns
+
+-------------------------------------------------------------------------------
+Even More Fibonacci 
+  With a long name
+-------------------------------------------------------------------------------
+/Users/rhayasd/Develop/github.com/rhysd/github-action-benchmark/examples/catch2/catch2_bench.cpp:26
+...............................................................................
+
+benchmark name                       samples       iterations    estimated
+                                     mean          low mean      high mean
+                                     std dev       low std dev   high std dev
+-------------------------------------------------------------------------------
+Fibonacci 10 with                                         100           208     7.1968 ms 
+a long name                                            344 ns        341 ns        349 ns 
+                                                        19 ns         11 ns         29 ns 
+                                                                                          
+Fibonacci 20                                              100             2     8.3712 ms 
+                                                    41.731 us      41.25 us     42.622 us 
+                                                     3.256 us      2.163 us      5.353 us 
+                                                                                                                                                  
                                                                                           
 
 ===============================================================================

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -86,7 +86,7 @@ describe('extractResult()', function() {
                     extra: '100 samples\n20 iterations',
                 },
                 {
-                    name: 'Fibonacci 10 with',
+                    name: 'Fibonacci 10 with a long name',
                     range: '± 19',
                     unit: 'ns',
                     value: 344,

--- a/test/extract.ts
+++ b/test/extract.ts
@@ -85,6 +85,20 @@ describe('extractResult()', function() {
                     value: 3.789,
                     extra: '100 samples\n20 iterations',
                 },
+                {
+                    name: 'Fibonacci 10 with',
+                    range: '± 19',
+                    unit: 'ns',
+                    value: 344,
+                    extra: '100 samples\n208 iterations',
+                },
+                {
+                    name: 'Fibonacci 20',
+                    range: '± 3.256',
+                    unit: 'us',
+                    value: 41.731,
+                    extra: '100 samples\n2 iterations',
+                },
             ],
         },
         {


### PR DESCRIPTION
If Benchmark names are too long, catch wraps them which caused the github action to fail. 
Adapted the regex to accommodate for this case.