### PR TITLE
Removing PERSONAL_GITHUB_TOKEN info

### DIFF
--- a/.github/workflows/benchmarkjs.yml
+++ b/.github/workflows/benchmarkjs.yml
@@ -19,8 +19,7 @@ jobs:
           name: Benchmark.js Benchmark
           tool: 'benchmarkjs'
           output-file-path: examples/benchmarkjs/output.txt
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'

--- a/.github/workflows/catch2.yml
+++ b/.github/workflows/catch2.yml
@@ -23,8 +23,7 @@ jobs:
           name: Catch2 Benchmark
           tool: "catch2"
           output-file-path: examples/catch2/benchmark_result.txt
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: "200%"

--- a/.github/workflows/cpp.yml
+++ b/.github/workflows/cpp.yml
@@ -23,8 +23,7 @@ jobs:
           name: C++ Benchmark
           tool: 'googlecpp'
           output-file-path: examples/cpp/benchmark_result.json
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'

--- a/.github/workflows/criterion-rs.yml
+++ b/.github/workflows/criterion-rs.yml
@@ -19,8 +19,7 @@ jobs:
                   name: Rust Benchmark
                   tool: 'cargo'
                   output-file-path: examples/criterion-rs/output.txt
-                  # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-                  github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   auto-push: true
                   # Show alert with commit comment on detecting possible performance regression
                   alert-threshold: '200%'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,8 +19,7 @@ jobs:
           name: Go Benchmark
           tool: 'go'
           output-file-path: examples/go/output.txt
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -22,8 +22,7 @@ jobs:
           name: Python Benchmark with pytest-benchmark
           tool: 'pytest'
           output-file-path: examples/pytest/output.json
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -19,8 +19,7 @@ jobs:
           name: Rust Benchmark
           tool: 'cargo'
           output-file-path: examples/rust/output.txt
-          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869/highlight/false
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           # Show alert with commit comment on detecting possible performance regression
           alert-threshold: '200%'

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In addition to the above setup, GitHub API token needs to be given to enable `co
 
 `secrets.GITHUB_TOKEN` is [a GitHub API token automatically generated for each workflow run][help-github-token].
 It is necessary to send a commit comment when the benchmark result of the commit is detected as possible
-performance regression.
+performance regression and also to update the dashboard on GitHub Pages.
 
 Now, in addition to making workflow fail, the step leaves a commit comment when it detects performance
 regression [like this][alert-comment-example]. Though `alert-comment-cc-users` input is not mandatory for
@@ -196,9 +196,7 @@ can be seen [here][commit-comment-workflow-example].
 It is useful to see how the benchmark results changed on each change in time-series charts. This action
 provides a chart dashboard on GitHub pages.
 
-It requires some preparations before the workflow setup.
-
-At first, you need to create a branch for GitHub Pages if you haven't created it yet.
+Before the workflow setup, you need to create a branch for GitHub Pages if you haven't yet done so.
 
 ```sh
 # Create a local branch
@@ -207,24 +205,7 @@ $ git checkout --orphan gh-pages
 $ git push origin gh-pages:gh-pages
 ```
 
-Second, you need to [create a personal access token][help-personal-access-token]. As of now,
-[deploying a GitHub Pages branch fails with `$GITHUB_TOKEN` automatically generated for workflows](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/td-p/26869).
-`$GITHUB_TOKEN` can push a branch to remote, but building GitHub Pages fails. Please read
-[issue #1](https://github.com/rhysd/github-action-benchmark/issues/1) for more details.
-This is a current limitation only for public repositories. For private repository, `secrets.GITHUB_TOKEN`
-is available. In the future, this issue would be resolved and we could simply use `$GITHUB_TOKEN` to
-deploy a GitHub Pages branch.
-
-1. Go to your user settings page
-2. Enter 'Developer settings' tab
-3. Enter 'Personal access tokens' tab
-4. Click 'Generate new token' and enter your favorite token name
-5. Check `repo` scope for `git push` and click 'Generate token' at bottom
-6. Go to your repository settings page
-7. Enter 'Secrets' tab
-8. Create new `PERSONAL_GITHUB_TOKEN` secret with a generated token string
-
-Now you're ready for workflow setup.
+Now, for the workflow setup.
 
 ```yaml
 jobs:
@@ -245,7 +226,7 @@ jobs:
           tool: 'go'
           output-file-path: output.txt
           # Personal access token to deploy GitHub Pages branch
-          github-token: ${{ secrets.PERSONAL_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           # Push and deploy GitHub pages branch automatically
           auto-push: true
 ```
@@ -273,8 +254,6 @@ benchmark results identical.
 
 Please see the above ['Examples' section](#examples) to see live workflow examples for each language.
 
-If you don't want to pass GitHub API token to this action, it's still OK.
-
 ```yaml
 - name: Store benchmark result
   uses: rhysd/github-action-benchmark@v1
@@ -286,7 +265,7 @@ If you don't want to pass GitHub API token to this action, it's still OK.
     auto-push: false
 # Push gh-pages branch by yourself
 - name: Push benchmark result
-  run: git push 'https://you:${{ secrets.PERSONAL_GITHUB_TOKEN }}@github.com/you/repo-name.git' gh-pages:gh-pages
+  run: git push gh-pages:gh-pages
 ```
 
 Please add a step to push the branch to the remote.
@@ -357,8 +336,7 @@ The path can be relative to repository root.
 - Type: String
 - Default: N/A
 
-GitHub API token. For updating a GitHub Pages branch with public repo, a personal access token is necessary.
-Please see the 'Commit comment' section for more details.
+GitHub API token. Note that `secrets.GITHUB_TOKEN` works by default for updating a GitHub Pages branch with either public or private repositories.
 
 #### `auto-push` (Optional)
 
@@ -374,8 +352,7 @@ Otherwise, you need to push it by your own. Please read 'Commit comment' section
 - Default: `false`
 
 If it is set to `true`, this action will leave a commit comment comparing the current benchmark with previous.
-`github-token` is necessary as well. Please note that a personal access token is not necessary to
-send a commit comment. `secrets.GITHUB_TOKEN` is sufficient.
+`github-token` is necessary as well.
 
 #### `save-data-file` (Optional)
 
@@ -402,9 +379,7 @@ See `comment-on-alert` and `fail-on-alert` also.
 - Default: `false`
 
 If it is set to `true`, this action will leave a commit comment when an alert happens [like this][alert-comment-example].
-`github-token` is necessary as well. Please note that a personal access token is not necessary to
-send a commit comment. `secrets.GITHUB_TOKEN` is sufficient. For the threshold for this, please see
-`alert-threshold` also.
+`github-token` is necessary as well.  For the threshold for this, please see `alert-threshold` also.
 
 #### `fail-on-alert` (Optional)
 
@@ -582,7 +557,6 @@ Every release will appear on your GitHub notifications page.
 [catch2-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Catch2+C%2B%2B+Example%22
 [help-watch-release]: https://help.github.com/en/github/receiving-notifications-about-activity-on-github/watching-and-unwatching-releases-for-a-repository
 [help-github-token]: https://help.github.com/en/actions/automating-your-workflow-with-github-actions/authenticating-with-the-github_token
-[help-personal-access-token]: https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line
 [minimal-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Example+for+minimal+setup
 [commit-comment-workflow-example]: https://github.com/rhysd/github-action-benchmark/actions?query=workflow%3A%22Example+for+alert+with+commit+comment
 [google-benchmark]: https://github.com/google/benchmark


### PR DESCRIPTION
I've noticed by trying to integrate benchmark regressions on [this repository](https://eullerborges.github.io/flexclass/) and reading into the [suggested link](https://github.community/t/github-action-not-triggering-gh-pages-upon-push/16096/24) that generating a personal token to update GitHub Pages was no longer necessary. 

I don't know if the team managing this repository is accepting pull requests, but I'm attempting to contribute a change that removes the related documentation for `PERSONAL_GITHUB_TOKEN` and also removes it from all the workflow examples. I took care to check that this would work in my fork, and verified that the GitHub Pages were properly updated, which you can [verify here](https://eullerborges.github.io/github-action-benchmark/dev/bench/).

Should you accept this, I'm not completely sure about the documentation and I'll gladly make any alterations you see fit there.

Removing the need for the personal token greatly reduces the barrier for first users, so hopefully this will help! It'd be great if we could also consider having a default for `github-token` to be `GITHUB_TOKEN`. I'd be willing to contribute that.