### PR TITLE
Fix parsing Rust benchmark lines that include MB/s

### DIFF
--- a/src/extract.ts
+++ b/src/extract.ts
@@ -178,7 +178,7 @@ function extractCargoResult(output: string): BenchmarkResult[] {
     const ret = [];
     // Example:
     //   test bench_fib_20 ... bench:      37,174 ns/iter (+/- 7,527)
-    const reExtract = /^test ([\w/]+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)$/;
+    const reExtract = /^test ([\w/]+)\s+\.\.\. bench:\s+([0-9,]+) ns\/iter \(\+\/- ([0-9,]+)\)(?: = \d+ MB\/s)?$/;
     const reComma = /,/g;
 
     for (const line of lines) {


### PR DESCRIPTION
Thanks for this awesome action! I was trying it out in hyper.rs, and noticed that lines that include the `MB/s` cause the extract to fail. This should fix that up.