### PR TITLE
Adding failsafe to the release script

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -47,7 +47,7 @@ cp -R node_modules .release/node_modules
 
 git checkout "$version"
 git pull
-git rm -rf node_modules
+git rm -rf node_modules --ignore-unmatch
 rm -rf node_modules  # remove node_modules/.cache
 mkdir -p src
 
@@ -56,7 +56,7 @@ mv .release/*.js ./src/
 mv .release/*.json .
 mv .release/node_modules .
 
-git add action.yml ./src/*.js package.json package-lock.json node_modules
+git add -f action.yml ./src/*.js package.json package-lock.json node_modules
 set +x
 
 echo "Done. Please check 'git diff --cached' to verify changes. If ok, add version tag and push it to remote"


### PR DESCRIPTION
When running the release script, I encountered a couple of issues. This PR attempts to make this script a bit less rigid and run to completion a bit more often than not

* git add -f. Added the -f as a user does not always have the proper git config to make that by default
* git rm --ignore-unmatch. Always exit with a status code of 0.
